### PR TITLE
Add customizable HeroSection

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,3 +1,0 @@
-export default function Hero() {
-  return <section className="bg-brand text-white px-6 py-15 grid md:grid-cols-2 gap-8 items-center">{/* ... */}</section>;
-}

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -1,0 +1,16 @@
+export default function HeroSection({ title, subtitle, buttonLink, image, imageAlt="" }) {
+  return (
+    <section className="bg-brand text-white px-6 py-15 grid gap-8 md:grid-cols-2 items-center">
+      <div>
+        <h1 className="text-[2.5rem] font-bold leading-[1.2] tracking-tight font-inter mb-4">{title}</h1>
+        <p className="text-lg font-normal leading-[1.5] tracking-normal font-inter mb-6">{subtitle}</p>
+        <a href={buttonLink} className="text-base font-semibold leading-[1.4] tracking-tight font-inter px-8 py-4 rounded-[16px] bg-white text-brand inline-block">
+          WhatsApp: Saiba como é feito na prática
+        </a>
+      </div>
+      <div>
+        <img src={image} alt={imageAlt} className="w-full rounded-[16px]" />
+      </div>
+    </section>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Header from '../components/Header';
-import Hero from '../components/Hero';
+import HeroSection from '../components/HeroSection';
 import Section from '../components/Section';
 import WaButton from '../components/WaButton';
 import BenefitCard from '../components/BenefitCard';
@@ -10,7 +10,12 @@ export default function Home() {
   return (
     <>
       <Header />
-      <Hero />
+      <HeroSection
+        title="Título do Produto"
+        subtitle="Subtítulo explicativo que convida o visitante"
+        buttonLink={CTA}
+        image="/ilustracao.png"
+      />
       <Section title="Terapia Quântica: Como Funciona" cols={2}>{/*...*/}</Section>
       <Section title="Benefícios da Energia Quântica" gray cols={3}>{/*...*/}</Section>
       <Section title="Perguntas Frequentes (FAQ)" gray><Accordion items={[]} /></Section>


### PR DESCRIPTION
## Summary
- add `HeroSection` component with title, subtitle, WhatsApp CTA and image
- remove unused `Hero` component
- use `HeroSection` on the home page

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846450d1bc48329b0719096a9deac1c